### PR TITLE
Added deepcopy of trigger method's return value

### DIFF
--- a/edap/edap.py
+++ b/edap/edap.py
@@ -142,7 +142,7 @@ class EdapDevice(ABC):
                     if sensor_value is not None:
                         self._last_sample['sensors'][trigger_sensor] = sensor_value
 
-        return self._last_sample
+        return deepcopy(self._last_sample)
 
     @abstractmethod
     def generate_sample(self, sample: EdapSample) -> EdapSample:


### PR DESCRIPTION
Code that uses this class can perform some further processing and formatting using the return value of `EdapDevice`'s `trigger` method. Use case that I've observed is transforming the `time` field from `datetime` to `str` in order to send the sample via websockets. That in turn, breaks the code, so we need to make sure that code uses a separate copy of the sample