### PR TITLE
Add example edap gateway implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ EDAP (Energy Device Access Protocol) is a standard developed by Emulate Energy t
 The primary way to use this is to implement a concrete subclass of the `EdapDevice` class, which means to implement the logic for generating an EDAP sample; as well as other required methods for logic that is specific to the particular device you want to represent.
 This library should give you all the logic regarding triggers that EDAP requires.
 
+In the `examples/basic-edap-gateway` there is a minimal implementation of a EDAP gateway, which can be useful to get an idea of how this can be used in practice.
 
 ## Installation
 Can be installed as a python package with `pip` via

--- a/examples/basic-edap-gateway/Dockerfile
+++ b/examples/basic-edap-gateway/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11.5-slim-bookworm
+
+# Install dumb-init and clean up apt leftovers
+RUN apt-get update && apt-get install -y --no-install-recommends \
+       dumb-init git openssh-client make \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create least-privilege group and user
+RUN groupadd -g 999 edapdocker && \
+    useradd -r -s /usr/bin/false -u 999 -g edapdocker edapdocker
+
+RUN mkdir -p /usr/share/sample-data/
+RUN chown 999 /usr/share/sample-data/
+
+WORKDIR /emulate/edapgateway
+
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY ./ ./
+
+USER 999
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["python", "main.py"]

--- a/examples/basic-edap-gateway/Makefile
+++ b/examples/basic-edap-gateway/Makefile
@@ -1,0 +1,14 @@
+deps:
+	pip install --no-cache-dir -r requirements.txt
+
+build-linux-image:
+	 docker build -f ./Dockerfile -t edap_gateway:latest --ssh=default .
+
+run-linux-container-local: build-linux-image
+	docker run --rm --name edap_gateway \
+	--net ghidorah_default \
+	-e LOG_LEVEL=DEBUG \
+	-e COMMANDER_PROXY_BASE_URL=ws://connect_commander_proxy:8000/ws/edap/ \
+	-e DEVICE_ID=b63b9773-d234-4415-99e7-3cac574d48ac \
+	-e RANDOM_DUMMY_DATA=true \
+	edap_gateway:latest

--- a/examples/basic-edap-gateway/main.py
+++ b/examples/basic-edap-gateway/main.py
@@ -1,0 +1,34 @@
+"""Entrypoint of the application."""
+import asyncio
+import logging
+import sys
+import os
+from src.utils import CustomJsonFormatter
+from src.Mediator import Mediator
+
+def main(event_loop: asyncio.AbstractEventLoop):
+    """Runs the gateway application."""
+    mediator = Mediator(event_loop)
+    try:
+        mediator.start()
+        event_loop.run_forever()
+    except KeyboardInterrupt:
+        ...
+    finally:
+        event_loop.run_until_complete(mediator.stop())
+
+def setup_logging():
+    """Sets up the logging configuration."""
+    logging.basicConfig(stream=sys.stdout, level=os.environ.get('LOG_LEVEL', 'INFO').upper())
+    logger = logging.getLogger()
+    logger.handlers.clear()
+    log_handler = logging.StreamHandler()
+    formatter = CustomJsonFormatter(service_name='edap-gateway')
+    log_handler.setFormatter(formatter)
+    logger.addHandler(log_handler)
+
+if __name__ == '__main__':
+    setup_logging()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    main(loop)

--- a/examples/basic-edap-gateway/readme.md
+++ b/examples/basic-edap-gateway/readme.md
@@ -1,0 +1,15 @@
+# Basic EDAP gateway implementation
+
+This is meant to be a barebones implementation of an EDAP gateway.
+We assume that it connects to a single device, and that we can control the power of that device, as well as read certain values from it.
+
+The specific implementation of the connection to the device will depend on the actual hardware.
+The application currenty starts with a `DummyDeviceConnection`, which just returns some dummy values, and has a `DummyEdapBattery` device, which mimics a basic battery. Both these classes needs real implementations, depending on the particular device and gateway setup.
+
+
+## Running it
+You can either create a virtual python environment, activate it and then run `make deps`, and then `python main.py` to start it, or you can build and run the application as a Docker container.
+The application depends on a few environment variables being set, namely the URL to the Emulate Commander Proxy service, and the device id of the device as it exists in the Emulate system (an uuid).
+
+In the makefile, the `run-linux-container-local` is an example setup for running the gateway against the local Emulate development environment.
+

--- a/examples/basic-edap-gateway/requirements.txt
+++ b/examples/basic-edap-gateway/requirements.txt
@@ -1,0 +1,4 @@
+websockets==11.0.3
+aiohttp==3.8.6
+python-json-logger==2.0.7
+edap @ git+https://github.com/Emulate-Energy/EDAP@main

--- a/examples/basic-edap-gateway/src/ConnectionManager.py
+++ b/examples/basic-edap-gateway/src/ConnectionManager.py
@@ -1,0 +1,133 @@
+"""Handles the WebSocket connection to the Emulate Commander proxy."""
+from typing import Optional
+import asyncio
+import logging
+import json
+import os
+import traceback
+from contextlib import suppress
+import websockets.client as ws_client
+import websockets.exceptions as ws_exceptions
+
+from src.utils import json_serialize
+
+class ConnectionManager:
+    """Handles the WebSocket connection to the Emulate Commander proxy."""
+    def __init__(self, mediator: Optional[None] = None) -> None:
+        self.__proxy_connection: Optional[ws_client.WebSocketClientProtocol] = None
+
+        self.__commander_proxy_base_url: Optional[str] = os.environ.get('COMMANDER_PROXY_BASE_URL')
+        self.__device_id: Optional[str] = os.environ.get('DEVICE_ID')
+
+        self.__connect_task: Optional[asyncio.Task] = None
+        self.__poll_task: Optional[asyncio.Task] = None
+        self.__close_proxy_connection_task: Optional[asyncio.Task] = None
+
+        self.mediator = mediator
+
+    async def __connect(self, retry_interval: int = 20):
+        if self.is_connected():
+            return
+        url = f'{self.__commander_proxy_base_url}{self.__device_id}'
+        while True:
+            try:
+                self.__proxy_connection = await ws_client.connect(uri=url, ping_interval=15)
+                logging.info({"message": "Connected to proxy",
+                              "url": url})
+                return
+            except (ws_exceptions.WebSocketException, OSError) as ex:
+                logging.warning({"message": "Could not connect to proxy",
+                                 "retry_interval": retry_interval,
+                                 "url": url,
+                                 "error": repr(ex),
+                                 "traceback": traceback.format_exc()})
+                await asyncio.sleep(retry_interval)
+
+    async def __poll_proxy_connection(self):
+        if not self.is_connected():
+            logging.warning({"message": "Not connected, polling won't start"})
+            return
+        try:
+            logging.info({"message": "Started to poll for proxy messages"})
+            while True:
+                received = await self.__proxy_connection.recv()
+                try:
+                    message = json.loads(received)
+                    if self.mediator:
+                        try:
+                            await self.mediator.notify("command_received", message)
+                        except Exception as ex:
+                            logging.error({"message": "Error occurred while handling command",
+                                           "error": repr(ex),
+                                           "traceback": traceback.format_exc()})
+                except json.JSONDecodeError as ex:
+                    logging.error({"message": "Error occurred while decoding message",
+                                   "received": received,
+                                   "error": repr(ex),
+                                   "traceback": traceback.format_exc()})
+        except (ws_exceptions.ConnectionClosed,
+                ws_exceptions.ConnectionClosedError) as ex:
+            logging.warning({"message": "Connection to proxy closed",
+                             "error": repr(ex),
+                             "traceback": traceback.format_exc()})
+
+    def __poll_task_done(self, _: asyncio.Task):
+        logging.info({"message": "Poll task done"})
+        self.__poll_task = None
+        self.__close_proxy_connection_task = asyncio.get_event_loop().create_task(
+            self.__close_proxy_connection())
+        self.__close_proxy_connection_task.add_done_callback(
+            self.__close_proxy_connection_task_done)
+
+    async def send_to_proxy(self, payload: dict):
+        """Sends a JSON payload to the proxy."""
+        try:
+            if self.is_connected():
+                await self.__proxy_connection.send(json.dumps(payload, default=json_serialize))
+                logging.debug({"message": "Payload to proxy sent",
+                              "payload": payload})
+            else:
+                logging.warning({"message": "Could not send, not connected to proxy"})
+        except ws_exceptions.WebSocketException as ex:
+            logging.warning({"message": "Could not send payload",
+                            "payload": payload,
+                            "error": repr(ex),
+                            "traceback": traceback.format_exc()})
+
+    async def __close_proxy_connection(self):
+        if self.__proxy_connection is not None and not self.__proxy_connection.closed:
+            await self.__proxy_connection.close()
+        logging.info({"message": "Proxy connection closed"})
+
+    def __close_proxy_connection_task_done(self, _: asyncio.Task):
+        self.__close_proxy_connection_task = None
+        self.start()
+
+    def is_connected(self) -> bool:
+        """If the proxy connection is open."""
+        return self.__proxy_connection is not None and self.__proxy_connection.open
+
+    def __start_poll(self, _: asyncio.Task):
+        self.__connect_task = None
+        if self.__poll_task is not None:
+            return
+        self.__poll_task = asyncio.get_event_loop().create_task(self.__poll_proxy_connection())
+        self.__poll_task.add_done_callback(self.__poll_task_done)
+
+    def start(self):
+        """Start polling for messages from the proxy."""
+        if self.__connect_task is not None:
+            return
+        self.__connect_task = asyncio.get_event_loop().create_task(self.__connect())
+        self.__connect_task.add_done_callback(self.__start_poll)
+
+    async def stop(self):
+        """Stop polling and disconnect from the proxy."""
+        tasks = [self.__connect_task, self.__poll_task, self.__close_proxy_connection_task]
+        for task in tasks:
+            if task is not None and not task.done() and not task.cancelled():
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+        if self.is_connected():
+            await self.__proxy_connection.close()

--- a/examples/basic-edap-gateway/src/DeviceConnection.py
+++ b/examples/basic-edap-gateway/src/DeviceConnection.py
@@ -1,0 +1,75 @@
+"""Abstract class that is responsible for managing the connection to the device/backend."""
+import os
+import asyncio
+import logging
+from contextlib import suppress
+from typing import Optional
+from datetime import timedelta
+from abc import ABC, abstractmethod
+
+DEFAULT_POLLING_INTERVAL = timedelta(seconds=1)
+
+class DeviceConnection(ABC):
+    """Class that is responsible for managing the connection to the device.
+    This involves sampling the device at regular intervals and passing the data onto the mediator,
+    and also handling incoming commands (like setting power) to the device.
+    Implementation will differ depending on specific hardware."""
+    def __init__(self, mediator, event_loop: asyncio.AbstractEventLoop):
+        self.mediator = mediator
+        self._event_loop = event_loop
+
+        polling_interval_s = int(os.environ.get('DEVICE_POLLING_INTERVAL',
+                                 DEFAULT_POLLING_INTERVAL.total_seconds()))
+        self.polling_interval = timedelta(seconds=polling_interval_s)
+
+        self._polling_loop_task: Optional[asyncio.Task] = None
+
+    @abstractmethod
+    def connect(self):
+        """Should handle connect to the device backend, if needed. Could be used for things like
+        opening a socket connection or setting up an authenticated session etc."""
+
+    @abstractmethod
+    def disconnect(self):
+        """Should handle disconnecting from the device backend, if needed."""
+
+    @abstractmethod
+    def send(self, data: dict):
+        """Should handle passing commands to the device."""
+
+    @abstractmethod
+    def _poll(self) -> dict:
+        return {}
+
+    def start(self):
+        """Connect if needed, and start the polling loop."""
+        self.connect()
+        logging.info({
+            "message": "Starting device polling loop",
+            "polling_interval": self.polling_interval.total_seconds()
+        })
+        self._polling_loop_task = self._event_loop.create_task(self._polling_loop())
+
+    async def _polling_loop(self):
+        # The following generator keeps a counter tracking when the next tick
+        # should happen, and yields the number of seconds we need to sleep to
+        # reach it. It should account for drift.
+        def g_tick():
+            next_tick_time = self._event_loop.time()
+            while True:
+                next_tick_time += self.polling_interval.total_seconds()
+                yield max(next_tick_time - self._event_loop.time(), 0)
+
+        g = g_tick()
+        with suppress(asyncio.CancelledError):
+            while True:
+                data = self._poll()
+                self.mediator.notify("sample_received", data)
+                await asyncio.sleep(next(g))
+
+
+    def stop(self):
+        """Disconnect if needed, and stop the polling loop."""
+        self.disconnect()
+        if self._polling_loop_task:
+            self._polling_loop_task.cancel()

--- a/examples/basic-edap-gateway/src/Mediator.py
+++ b/examples/basic-edap-gateway/src/Mediator.py
@@ -1,0 +1,102 @@
+"""Central component that mediates between the device and the proxy."""
+import asyncio
+from typing import Any, Literal
+import logging
+from datetime import datetime, timezone
+
+from src.ConnectionManager import ConnectionManager
+from src.DeviceConnection import DeviceConnection
+from src.dummy.DummyDeviceConnection import DummyDeviceConnection
+from src.dummy.DummyEdapBattery import DummyEdapBattery
+
+EventType = Literal["sample_received", "trigger_activated", "command_received"]
+CommandType = Literal["set", "set_triggers", "ping"]
+
+class Mediator:
+    """Class that acts as a mediator between the device and the proxy."""
+    _event_loop: asyncio.AbstractEventLoop
+    connection_manager: ConnectionManager
+    device_connection: DeviceConnection
+    device: DummyEdapBattery
+
+    def __init__(self, event_loop: asyncio.AbstractEventLoop):
+        self._event_loop = event_loop
+        self.connection_manager = ConnectionManager(self)
+        self.device_connection = DummyDeviceConnection(self, event_loop)
+        self.device = DummyEdapBattery(self)
+
+    def notify(self, event: EventType, data: Any = None):
+        """React to different kinds of events, triggered by one of the components."""
+        self._event_loop.create_task(self.__inner_notify(event, data))
+
+    async def __inner_notify(self, event: EventType, data: Any):
+        match event:
+            case "trigger_activated":
+                await self.connection_manager.send_to_proxy(data)
+                logging.debug({"message": "Trigger activated", "trigger": data})
+            case "command_received":
+                self.handle_commands(data)
+            case "sample_received":
+                self.device.update_from_sample(data)
+            case _:
+                logging.error({"message": "Unknown event", "event": event})
+                return False
+        return True
+
+    def handle_commands(self, command: dict):
+        """React to incoming command from the proxy."""
+        command_time: datetime = None
+        if "time" in command:
+            # no need to account for timestamps that end with Z since python 3.11
+            command_time = datetime.fromisoformat(command["time"])
+            del command["time"]
+        else:
+            command_time = datetime.now(tz=timezone.utc)
+
+        for command_name, command_data in command.items():
+            match command_name:
+                case "set":
+                    try:
+                        self.device_connection.send(command_data)
+                        result = {"result": "success"}
+                    except Exception as ex:
+                        result = {"result": "error", "error": repr(ex)}
+                case "set_triggers":
+                    try:
+                        self.device.set_triggers(command_data)
+                        result = {"result": "success"}
+                    except Exception as ex:
+                        result = {"result": "error", "error": repr(ex)}
+                case "ping":
+                    result = {"result": "pong"}
+                case _:
+                    logging.error({"message": "Unknown command", "command": command_name})
+                    return
+            self._event_loop.create_task(
+                self.send_command_response(command_name, command_time, result))
+
+    async def send_command_response(self, command_name: str, command_time: datetime, result: dict):
+        """Constructs and sends a response to a command."""
+        if not result:
+            return
+        now = datetime.now(tz=timezone.utc)
+        duration_ms = round((now - command_time).total_seconds() * 1000, 4)
+        command_response = {
+            "command": command_name,
+            "duration": duration_ms,
+            "time": command_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+            "result": result,
+        }
+        await self.connection_manager.send_to_proxy(command_response)
+
+    def start(self):
+        """Start the different components of the mediator."""
+        logging.info("Starting the Edap gateway...")
+        self.connection_manager.start()
+        self.device_connection.start()
+
+    async def stop(self):
+        """Stop the different components of the mediator."""
+        logging.info("Shutting down the Edap gateway...")
+        await self.connection_manager.stop()
+        self.device_connection.stop()

--- a/examples/basic-edap-gateway/src/dummy/DummyDeviceConnection.py
+++ b/examples/basic-edap-gateway/src/dummy/DummyDeviceConnection.py
@@ -1,0 +1,40 @@
+"""Dummy backend device connection class, producing dummy data."""
+import os
+import asyncio
+import logging
+from random import random
+
+from src.DeviceConnection import DeviceConnection
+
+
+class DummyDeviceConnection(DeviceConnection):
+    """Dummy device connection class that simulates a device connection."""
+
+    power: float = 0.0
+    soc: float = 0.50
+    random_data: bool
+
+    def __init__(self, mediator, event_loop: asyncio.AbstractEventLoop):
+        super().__init__(mediator, event_loop)
+        random_data = os.environ.get("RANDOM_DUMMY_DATA", 'false')
+        self.random_data = random_data.lower() == 'true'
+
+    def connect(self):
+        logging.debug({"message": "Connecting to dummy device"})
+
+    def disconnect(self):
+        logging.debug({"message": "Disconnecting from dummy device"})
+
+    def send(self, data):
+        logging.debug({"message": "Sending data to dummy device", "data": data})
+        if "power" in data:
+            self.power = data["power"]
+
+    def _poll(self) -> dict:
+        if self.random_data:
+            self.power = random() * 100
+            self.soc = random()
+        return {
+            "power": self.power,
+            "soc": self.soc
+        }

--- a/examples/basic-edap-gateway/src/dummy/DummyEdapBattery.py
+++ b/examples/basic-edap-gateway/src/dummy/DummyEdapBattery.py
@@ -1,0 +1,68 @@
+"""Dummy implementation of an EDAP device."""
+import logging
+from datetime import datetime, timezone
+from edap import EdapDevice, EdapSample, Trigger
+
+
+class DummyEdapBattery(EdapDevice):
+    """Dummy implementation of an EDAP device."""
+    power_kw: float = 0.0
+    soc: float = 0.50
+    energy_capacity = 100.0 # kWh
+    energy: float = 0.0
+    last_sample_time: datetime # when the last device sample received
+    last_triggered: datetime  # when the last trigger was activated
+
+    def __init__(self, mediator):
+        self.mediator = mediator
+        self.last_sample_time = None
+        self.last_triggered = None
+
+        # add a default time trigger just for testing
+        default_time_trigger: Trigger = Trigger(
+            id="time",
+            property="time",
+            delta=10
+        )
+        super().__init__([default_time_trigger])
+
+    def update_from_sample(self, data: dict):
+        """Update the device state from a polling sample, and check if any triggers are activated,
+        notifying the mediator if so."""
+        logging.debug({"message": "Updating device from sample", "data": data})
+        self.power_kw = data["power"]
+        self.soc = data["soc"]
+
+        now = datetime.now(tz=timezone.utc)
+        if self.last_sample_time:
+            since_last_sample = now - self.last_sample_time
+            self.energy += self.power_kw * since_last_sample.total_seconds() / 3600
+
+        self.last_sample_time = now
+
+        sample = EdapSample(
+            triggers = [],
+            time = now,
+            power = 0.0,
+            energy = 0.0,
+            duration = 0.0,
+            sensors = {},
+            sample_energy = 0.0,
+        )
+
+        maybe_sample = self.trigger(sample)
+        if maybe_sample is not None:
+            self.last_triggered = now
+            self.mediator.notify("trigger_activated", maybe_sample)
+
+    def generate_sample(self, sample: EdapSample) -> dict:
+        sample["power"] = self.power_kw
+        sample["sensors"]["soc"] = self.soc
+        sample["energy"] = self.energy
+        sample["sensors"]["remaining_energy"] = self.soc * self.energy_capacity
+
+        if self.last_triggered:
+            now = datetime.now(tz=timezone.utc)
+            sample["duration"] = (now - self.last_triggered).total_seconds()
+
+        return sample

--- a/examples/basic-edap-gateway/src/dummy/DummyEdapBattery.py
+++ b/examples/basic-edap-gateway/src/dummy/DummyEdapBattery.py
@@ -41,13 +41,10 @@ class DummyEdapBattery(EdapDevice):
         self.last_sample_time = now
 
         sample = EdapSample(
-            triggers = [],
             time = now,
-            power = 0.0,
-            energy = 0.0,
-            duration = 0.0,
-            sensors = {},
-            sample_energy = 0.0,
+            power = self.power_kw,
+            energy = self.energy,
+            sensors = {"soc": self.soc, "remaining_energy": self.soc * self.energy_capacity},
         )
 
         maybe_sample = self.trigger(sample)
@@ -56,13 +53,7 @@ class DummyEdapBattery(EdapDevice):
             self.mediator.notify("trigger_activated", maybe_sample)
 
     def generate_sample(self, sample: EdapSample) -> dict:
-        sample["power"] = self.power_kw
-        sample["sensors"]["soc"] = self.soc
-        sample["energy"] = self.energy
-        sample["sensors"]["remaining_energy"] = self.soc * self.energy_capacity
-
-        if self.last_triggered:
-            now = datetime.now(tz=timezone.utc)
-            sample["duration"] = (now - self.last_triggered).total_seconds()
-
+        sample.duration = (sample.time-self._last_sample.time).total_seconds()
+        sample.sample_energy = sample.energy-self._last_sample.energy
+        sample.triggers = []
         return sample

--- a/examples/basic-edap-gateway/src/dummy/DummyEdapBattery.py
+++ b/examples/basic-edap-gateway/src/dummy/DummyEdapBattery.py
@@ -53,7 +53,7 @@ class DummyEdapBattery(EdapDevice):
             self.mediator.notify("trigger_activated", maybe_sample)
 
     def generate_sample(self, sample: EdapSample) -> dict:
-        sample.duration = (sample.time-self._last_sample.time).total_seconds()
-        sample.sample_energy = sample.energy-self._last_sample.energy
-        sample.triggers = []
+        sample["duration"] = (sample["time"] - self._last_sample["time"]).total_seconds()
+        sample["sample_energy"] = sample["energy"] - self._last_sample["energy"]
+        sample["triggers"] = []
         return sample

--- a/examples/basic-edap-gateway/src/dummy/readme.md
+++ b/examples/basic-edap-gateway/src/dummy/readme.md
@@ -1,0 +1,6 @@
+# Dummy implementations
+These files do not reflect any real hardware, but just produce some mocked data.
+In a real implementation the `DeviceConnection` implementation should do things like for example read values from ModBus registers, or get data from an internal api, or whatever is needed.
+
+The real EdapDevice implementation should similarly keep whatever state variables necessary, and add the logic to construct appropriate Edap samples (i.e. a battery should fill in the state of charge (soc), while an HVAC system should fill in temperature data, and so on.).
+

--- a/examples/basic-edap-gateway/src/utils.py
+++ b/examples/basic-edap-gateway/src/utils.py
@@ -1,0 +1,33 @@
+"""Some utility functions, mostly for logging."""
+import logging
+from typing import Any
+from datetime import datetime, date, timezone
+from pythonjsonlogger import jsonlogger
+
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    """Custom JSON Formatter class for logging"""
+    service_name: str
+
+    def __init__(self, service_name: str):
+        super().__init__()
+        self.service_name = service_name
+
+    def add_fields(self, log_record: dict[str, Any], record: logging.LogRecord,
+                   message_dict: dict[str, Any]):
+        """Add custom fields to the log record."""
+        super().add_fields(log_record, record, message_dict)
+        log_record['service'] = self.service_name
+        if not log_record.get('timestamp'):
+            # this doesn't use record.created, so it is slightly off
+            now = datetime.now(tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            log_record['timestamp'] = now
+        if log_record.get('level'):
+            log_record['level'] = log_record['level'].lower()
+        else:
+            log_record['level'] = record.levelname.lower()
+
+def json_serialize(obj):
+    """Serialize datetime and date objects to isoformat strings."""
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    return str(obj)


### PR DESCRIPTION
Adds a fairly minimal implementation of a single device EDAP gateway, which is essentially a very stripped down version of the `edap_docker` (Bravida) gateway logic; presumably fairly similar to what Th1ng has implemented (but with proper trigger support). This version interfaces with a single device, handling the WS connection to our Commander Proxy and implementing the trigger logic and logic for building and emitting EDAP samples. 

The part of the logic that handles the connection between the gateway and the device is completely mocked, I just put in how we generally want to poll and pass data, since the actual implementation will depend on the actual hardware, if one should read and write to Modbus registers or use an internal API of some sort etc. In the `edap_docker` gateway, this is handled by the `BACNet` logic.

