### PR TITLE
add_static_apply_trigger_method

### DIFF
--- a/edap/edap.py
+++ b/edap/edap.py
@@ -202,7 +202,10 @@ class EdapDevice(ABC):
 
     @staticmethod
     def apply_trigger(sample: EdapSample, triggers: list[Trigger]) -> EdapSample | None:
-        """Check if a sample activates any triggers. Returns a triggered EdapSample with activated trigger IDs, or None if no triggers fired."""
+        """Check if a sample activates any triggers. Returns a triggered EdapSample with activated trigger IDs, or None if no triggers fired.
+        To be noted is the input "triggers" object will be updated with the values of the activated triggers and their conditions,
+        but the returned EdapSample will have the trigger IDs in the "triggers" list and not the full trigger objects.
+        This is to avoid confusion about what properties are part of the triggered sample and what are part of the trigger definition."""
         conditions: dict[str, Trigger] = {}
         for t in triggers:
             condition = t.get("condition")

--- a/edap/edap.py
+++ b/edap/edap.py
@@ -43,7 +43,6 @@ class EdapDevice(ABC):
     def __init__(self, triggers: list[Trigger] | None = None) -> None:
         self._triggers: list[Trigger] = []
         self._last_sample: EdapSample | None = None
-        self._conditions: dict[str, Trigger] = {}
         self.set_triggers(triggers)
 
     def get_triggers(self) -> list[Trigger]:
@@ -54,11 +53,6 @@ class EdapDevice(ABC):
             self._triggers = []
         else:
             self._triggers = triggers
-        self._conditions = {}
-        for trigger in self._triggers:
-            condition = trigger.get("condition")
-            if condition is not None:
-                self._conditions[condition] = trigger
 
     @staticmethod
     def _delta_triggered(current_sample_value: _MeasurementValue, trigger: Trigger) -> bool:

--- a/edap/edap.py
+++ b/edap/edap.py
@@ -43,7 +43,6 @@ class EdapDevice(ABC):
     def __init__(self, triggers: list[Trigger] | None = None) -> None:
         self._triggers: list[Trigger] = []
         self._last_sample: EdapSample | None = None
-        self._property_failures: dict[str, int] = {}
         self._conditions: dict[str, Trigger] = {}
         self.set_triggers(triggers)
 
@@ -110,10 +109,13 @@ class EdapDevice(ABC):
         return False
 
     @staticmethod
-    def _is_tolerance_triggered(trigger: Trigger, failures: int | None, exact_equals: bool) -> bool:
-        tolerance: int | None = trigger.get('tolerance')
-        if tolerance is not None and failures is not None:
-            return (exact_equals and failures == tolerance) or (not exact_equals and failures >= tolerance)
+    def _tolerance_triggered(current_sample_value: _SampleValue, trigger: Trigger) -> bool:
+        if "tolerance" not in trigger:
+            return False
+        trigger_value = trigger["value"]
+        has_value = current_sample_value.exists and current_sample_value.value is not None
+        if (trigger_value is None and has_value) or (trigger_value is not None and not has_value):
+            return True
         return False
 
     @staticmethod
@@ -171,86 +173,99 @@ class EdapDevice(ABC):
             return False
         return True
 
-    def _single_trigger_activated(self, current_sample: EdapSample, trigger: Trigger) -> bool:
+    @staticmethod
+    def _single_trigger_activated(
+        current_sample: EdapSample,
+        trigger: Trigger,
+        conditions: dict[str, Trigger],
+    ) -> bool:
         trigger_property: str | None = trigger.get('property')
         if trigger_property is None:
             return False
         try:
             if "conditions" in trigger:
                 for condition in trigger.get("conditions") or []:
-                    if condition in self._conditions and not self._single_trigger_activated(current_sample, self._conditions.get(condition, {})):
+                    if condition in conditions and not EdapDevice._single_trigger_activated(
+                        current_sample, conditions.get(condition, {}), conditions
+                    ):
                         return False
 
             if trigger_property == "time":
-                return self._is_time_triggered(current_sample.get('time'), trigger)
-            current_sample_value = self._get_sample_value(current_sample, trigger_property)
-            if not current_sample_value.exists or current_sample_value.value is None:
-                self._property_failures[trigger_property] = self._property_failures.get(trigger_property, 0) + 1
-                return self._is_tolerance_triggered(trigger, self._property_failures[trigger_property], True)
-            if "condition" in trigger and self._condition_triggered(current_sample_value.value, trigger):
+                return EdapDevice._is_time_triggered(current_sample.get('time'), trigger)
+            current_sample_value = EdapDevice._get_sample_value(current_sample, trigger_property)
+            if "condition" in trigger and EdapDevice._condition_triggered(current_sample_value.value, trigger):
                 return True
-            tolerance_triggered = self._is_tolerance_triggered(trigger, self._property_failures.get(trigger_property), False)
-            self._property_failures[trigger_property] = 0
+
             return (
-                tolerance_triggered
-                or self._level_triggered(current_sample_value.value, trigger)
-                or self._delta_triggered(current_sample_value.value, trigger)
+                EdapDevice._tolerance_triggered(current_sample_value, trigger)
+                or EdapDevice._level_triggered(current_sample_value.value, trigger)
+                or EdapDevice._delta_triggered(current_sample_value.value, trigger)
             )
         except Exception as e:
             logging.error("EdapDevice error: Error processing trigger %s: %s", trigger, e, exc_info=True)
 
         return False
 
-    def trigger(self, sample: EdapSample) -> EdapSample | None:
-        """If some triggers were activated, return modified sample with trigger list inside, otherwise, return None"""
-        full_activated_triggers: list[Trigger] = []
+    @staticmethod
+    def apply_trigger(sample: EdapSample, triggers: list[Trigger]) -> EdapSample | None:
+        """Check if a sample activates any triggers. Returns a triggered EdapSample with activated trigger IDs, or None if no triggers fired."""
+        conditions: dict[str, Trigger] = {}
+        for t in triggers:
+            condition = t.get("condition")
+            if condition is not None:
+                conditions[condition] = t
 
-        for trigger in self._triggers:
-            if "id" in trigger and self._single_trigger_activated(sample, trigger):
+        full_activated_triggers: list[Trigger] = []
+        for trigger in triggers:
+            if "id" in trigger and EdapDevice._single_trigger_activated(sample, trigger, conditions):
                 full_activated_triggers.append(trigger)
 
-        if len(full_activated_triggers) == 0:
+        if not full_activated_triggers:
             return None
 
-        self._last_sample = self.generate_sample(sample)
+        result = EdapDevice.generate_sample(sample)
         sensors: dict = sample.get('sensors') or {}
 
         for trigger in full_activated_triggers:
             trigger_property = trigger.get('property')
 
-            # update the values of activated triggers
-            trigger_value = self._get_sample_value(sample, trigger_property)
+            trigger_value = EdapDevice._get_sample_value(sample, trigger_property)
             if trigger_value.exists:
                 trigger['value'] = trigger_value.value
             for condition in trigger.get("conditions") or []:
-                condition_property =  self._conditions.get(condition, {}).get('property', None)
+                condition_property = conditions.get(condition, {}).get('property', None)
                 if condition_property:
-                    condition_value = self._get_sample_value(sample, condition_property)
+                    condition_value = EdapDevice._get_sample_value(sample, condition_property)
                     if condition_value.exists:
-                        self._conditions[condition]['value'] = condition_value.value
+                        conditions[condition]['value'] = condition_value.value
 
-            # if the trigger tells us to discard the sample, we add a # in front of the trigger id
             trigger_id = trigger.get("id")
             if trigger.get('discard_sample', False):
                 trigger_id = f"#{trigger_id}"
 
-            # add ids of activated triggers to EDAP sample
             if trigger_id:
-                self._last_sample['triggers'].append(trigger_id)
+                result['triggers'].append(trigger_id)
 
-            if len(self._last_sample['sensors']) == len(sensors):
+            if len(result['sensors']) == len(sensors):
                 continue
 
             trigger_sensors: list[str] | None = trigger.get('sensors')
             if trigger_sensors is None:
-                self._last_sample['sensors'] = deepcopy(sensors)
+                result['sensors'] = deepcopy(sensors)
             else:
                 for trigger_sensor in trigger_sensors:
                     sensor_value = sensors.get(trigger_sensor)
                     if sensor_value is not None:
-                        self._last_sample['sensors'][trigger_sensor] = sensor_value
+                        result['sensors'][trigger_sensor] = sensor_value
 
-        return deepcopy(self._last_sample)
+        return deepcopy(result)
+
+    def trigger(self, sample: EdapSample) -> EdapSample | None:
+        """If some triggers were activated, return modified sample with trigger list inside, otherwise, return None"""
+        result = self.apply_trigger(sample, self._triggers)
+        if result is not None:
+            self._last_sample = result
+        return result
 
     @staticmethod
     def generate_sample(sample: EdapSample) -> EdapSample:

--- a/tests/test_edap.py
+++ b/tests/test_edap.py
@@ -133,19 +133,15 @@ def test_tolerance_trigger():
     ])
 
     triggered_sample = edap_device.trigger({"power": None})
-    # number of failures for power is 1
-    assert triggered_sample is None
-
-    triggered_sample = edap_device.trigger({"power": None})
-    # number of failures for power is 2, tolerance reached, trigger activated
+    # last known value was 20 (not None), now None — value disappeared, trigger activated
     assert triggered_sample is not None
 
     triggered_sample = edap_device.trigger({"power": None})
-    # number of failures for power is 3, but the value is still None, trigger not activated
+    # last known value is now None, still None — no transition, trigger not activated
     assert triggered_sample is None
 
     triggered_sample = edap_device.trigger({"power": 21})
-    # number of failures for power was 3, but the value is present, trigger activated and count is reset
+    # last known value was None, now 21 — value appeared, trigger activated
     assert triggered_sample is not None
 
 
@@ -331,6 +327,122 @@ def test_level_trigger_triggers_after_initial_value_on_level() -> None:
     assert sample_1 is None
     assert sample_2 is not None
     assert sample_3 is not None
+
+def test_apply_trigger_no_instance_needed() -> None:
+    # apply_trigger is a static method — callable without an EdapDevice instance
+    triggers = [{"property": "power", "delta": 2, "value": 20, "id": "power_id"}]
+    result = EdapDevice.apply_trigger({"power": 23}, triggers)
+    assert result is not None
+    assert result["triggers"] == ["power_id"]
+
+
+def test_apply_trigger_returns_none_when_no_triggers_fire() -> None:
+    triggers = [{"property": "power", "delta": 2, "value": 20, "id": "power_id"}]
+    assert EdapDevice.apply_trigger({"power": 21}, triggers) is None
+
+
+def test_apply_trigger_returns_none_for_empty_triggers() -> None:
+    assert EdapDevice.apply_trigger({"power": 100}, []) is None
+
+
+def test_apply_trigger_result_contains_sample_fields() -> None:
+    sample_time = datetime.now(timezone.utc)
+    triggers = [{"property": "power", "delta": 2, "value": 20, "id": "power_id"}]
+    result = EdapDevice.apply_trigger({"time": sample_time, "power": 25, "energy": 10}, triggers)
+    assert result is not None
+    assert result["time"] == sample_time
+    assert result["power"] == 25
+    assert result["energy"] == 10
+
+
+def test_apply_trigger_is_stateless_between_calls() -> None:
+    # apply_trigger builds its own conditions state per call — two calls with
+    # identical fresh trigger copies produce identical results
+    from copy import deepcopy
+    triggers = [{"property": "power", "delta": 2, "value": 20, "id": "power_id"}]
+    sample = {"power": 25}
+    result_1 = EdapDevice.apply_trigger(sample, deepcopy(triggers))
+    result_2 = EdapDevice.apply_trigger(sample, deepcopy(triggers))
+    assert result_1 is not None
+    assert result_2 is not None
+    assert result_1["triggers"] == result_2["triggers"]
+
+
+def test_apply_trigger_updates_trigger_value_on_activation() -> None:
+    triggers = [{"property": "power", "delta": 2, "value": 20, "id": "power_id"}]
+    EdapDevice.apply_trigger({"power": 25}, triggers)
+    assert triggers[0]["value"] == 25
+
+
+def test_apply_trigger_does_not_mutate_trigger_value_when_not_activated() -> None:
+    triggers = [{"property": "power", "delta": 2, "value": 20, "id": "power_id"}]
+    EdapDevice.apply_trigger({"power": 21}, triggers)
+    assert triggers[0]["value"] == 20
+
+
+def test_apply_trigger_discard_sample_prefixes_trigger_id() -> None:
+    triggers = [{"property": "power", "delta": 2, "value": 20, "id": "power_id", "discard_sample": True}]
+    result = EdapDevice.apply_trigger({"power": 25}, triggers)
+    assert result is not None
+    assert result["triggers"] == ["#power_id"]
+
+
+def test_apply_trigger_sensors_populated_by_trigger_without_sensors_list() -> None:
+    # A trigger with no 'sensors' key copies all sensors into the result
+    triggers = [{"property": "power", "delta": 2, "value": 20, "id": "power_id"}]
+    sample = {"power": 25, "sensors": {"temp": 30, "voltage": 400}}
+    result = EdapDevice.apply_trigger(sample, triggers)
+    assert result is not None
+    assert result["sensors"] == {"temp": 30, "voltage": 400}
+
+
+def test_apply_trigger_sensors_filtered_by_trigger_sensors_list() -> None:
+    # A trigger with a 'sensors' list copies only the listed sensors into the result
+    triggers = [{"property": "power", "delta": 2, "value": 20, "id": "power_id", "sensors": ["temp"]}]
+    sample = {"power": 25, "sensors": {"temp": 30, "voltage": 400}}
+    result = EdapDevice.apply_trigger(sample, triggers)
+    assert result is not None
+    assert result["sensors"] == {"temp": 30}
+    assert "voltage" not in result["sensors"]
+
+
+def test_apply_trigger_condition_triggers() -> None:
+    triggers = [
+        {"id": "delta_1", "property": "power", "delta": 2, "conditions": ["c1"]},
+        {"condition": "c1", "property": "power", "greater": 10, "less": 30},
+    ]
+    # no prior value and c1 satisfied (10 < 15 < 30) → fires; trigger value updated to 15
+    result = EdapDevice.apply_trigger({"power": 15}, triggers)
+    assert result is not None
+    assert result["triggers"] == ["delta_1"]
+
+    # delta |17-15|=2 not > 2 → doesn't fire
+    assert EdapDevice.apply_trigger({"power": 17}, triggers) is None
+
+    # delta |18-15|=3 > 2 and c1 satisfied → fires; trigger value updated to 18
+    assert EdapDevice.apply_trigger({"power": 18}, triggers) is not None
+
+    # power=35 fails c1 (35 >= 30) → doesn't fire even though delta would be large enough
+    assert EdapDevice.apply_trigger({"power": 35}, triggers) is None
+
+
+def test_apply_trigger_tolerance_transition() -> None:
+    # Tolerance triggers on value↔no-value transition (stateless, checked each call independently)
+    triggers = [{"property": "power", "value": 20, "tolerance": 1, "id": "power_id"}]
+
+    # had value, now None → triggers
+    result = EdapDevice.apply_trigger({"power": None}, triggers)
+    assert result is not None
+
+    # trigger value was updated to None; still None → no trigger
+    assert triggers[0]["value"] is None
+    result = EdapDevice.apply_trigger({"power": None}, triggers)
+    assert result is None
+
+    # was None, now has value → triggers
+    result = EdapDevice.apply_trigger({"power": 20}, triggers)
+    assert result is not None
+
 
 @pytest.mark.parametrize("delta_value", [None, 0, 0.1])
 def test_delta_trigger_triggers_on_bool_change(delta_value: float | int | None) -> None:


### PR DESCRIPTION
So we want to be able to simply the mechanics of EDAP trigger to always be able to evaluate a a triggered sample from an EDAP sample and the current trigger spec. The previous "tolerance count" needed to keep the current number of consecutive null values in memory, and have now been replaced with a trigger whenever a sensor goes from a value to null or from null to a value. 